### PR TITLE
Do not install one more curl into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN cd curl && \
 
 
 FROM ubuntu:20.04
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /ubuntu/usr/local/ /usr/local/
 COPY --from=builder /opt/quiche/target/release /opt/quiche/target/release


### PR DESCRIPTION
Otherwise there will be 2 curls inside image:
* /usr/bin/curl (from deb pkg)
* /usr/local/bin/curl (compiled one)

We need only ca-certificates for /usr/local/bin/curl, so it can check certificates validity.

Also clean apt cache to reduce image size.